### PR TITLE
Test: Without a title, a record cannot be opened

### DIFF
--- a/_attachments/tests/MissingTitleTest.html
+++ b/_attachments/tests/MissingTitleTest.html
@@ -36,21 +36,6 @@
 	<td>class=error</td>
 	<td></td>
 </tr>
-<tr>
-	<td>clickAndWait</td>
-	<td>link=Retour</td>
-	<td></td>
-</tr>
-<tr>
-	<td>open</td>
-	<td>${noticeUrl}</td>
-	<td></td>
-</tr>
-<tr>
-	<td>verifyTextPresent</td>
-	<td>{&quot;error&quot;:&quot;not_found&quot;,&quot;reason&quot;:&quot;document not found&quot;}</td>
-	<td></td>
-</tr>
 
 </tbody></table>
 </body>


### PR DESCRIPTION
It is a Selenium 1.7.2 Test.

I decided to check two things : 
1. When one submits an empty title form, an error should appear, with the following html value : "class=error"
2. If an empty title form is filled, there shouldn't be a page with the id given in the URL.
