### PR TITLE
TEST: In BibTeX import, author name containing "and"

### DIFF
--- a/spec/features/record_import.rb
+++ b/spec/features/record_import.rb
@@ -7,6 +7,12 @@ feature 'Import a record' do
     click_on 'Créer...'
     click_on 'Importer...'
   end
+  
+  scenario 'TEST_AND' do
+    fill_in 'bibtex', :with => sample('and')
+    click_on 'Importer'
+    field('creator').should == 'Alexandre Lepetit'
+  end
 
   scenario 'from ACM' do
     fill_in 'bibtex', :with => sample('acm')

--- a/spec/samples/and.bib
+++ b/spec/samples/and.bib
@@ -1,0 +1,3 @@
+@inproceedings{Merle:2012:DDA:2389176.2389195,
+ author = {Lepetit, Alexandre}
+ }


### PR DESCRIPTION
is processed as two different authors (issue #98).
