### PR TITLE
DOC : Delete tire-a-part from notice

### DIFF
--- a/features/supprimer_tire-a-part_dune_notice.feature
+++ b/features/supprimer_tire-a-part_dune_notice.feature
@@ -1,0 +1,9 @@
+﻿#language:fr
+
+Fonctionnalité: Supprimer un tiré-à-part d'une notice
+
+Scénario: Suppression d'un tiré-à-part
+
+ Etant donné une notice à laquelle est attaché un tiré-à-part
+ Quand je supprime le tiré-à-part
+ Alors aucun tiré-à-part n'est plus attaché à la notice


### PR DESCRIPTION
Ajout du scénario de la fonctionnalité : "supprimer un tiré-à-part d'une notice"