### PR TITLE
TEST: Delete a tire-a-part from a notice

### DIFF
--- a/features/step_definitions/supprimer_tire_a_part.rb
+++ b/features/step_definitions/supprimer_tire_a_part.rb
@@ -1,0 +1,15 @@
+require('capybara/cucumber')
+
+Etantdonné(/^une "([^"]*)" à laquelle est attaché un "([^"]*)"$/) do |notice, tire-a-part|
+  visit('https://publications.icd.utt.fr/' + notice)
+  expect(page).to have_content(tire-a-part)
+end
+
+Quand(/^je supprime le "([^"]*)"$/) do |tire-a-part|
+   click_button 'Supprimer le Tiré-à-part.'
+end
+
+Alors(/^aucun "([^"]*)" n'est plus attaché à la "([^"]*)"$/) do |tire-a-part, notice|
+  visit('https://publications.icd.utt.fr/' + notice)
+  page.should_not have_content(tire-a-part)
+end


### PR DESCRIPTION
Test de recette pour le fonctionnalité : "supprimer un tire-a-part" basé
sur le scénario de la pull request #182